### PR TITLE
Fixes to allow Lambda to be run

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/referencegenerator/LambdaRunner.scala
+++ b/src/main/scala/uk/gov/nationalarchives/referencegenerator/LambdaRunner.scala
@@ -3,5 +3,5 @@ package uk.gov.nationalarchives.referencegenerator
 import uk.gov.nationalarchives.referencegenerator.Lambda.Input
 
 object LambdaRunner extends App {
-  Lambda().process(Input(0))
+  new Lambda().process(Input(0))
 }

--- a/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
@@ -17,8 +17,8 @@ class LambdaTest extends AnyFlatSpec with Matchers with TestContainerUtils {
     val client = createDynamoDbClient(container)
     val input = Lambda.Input(numberOfReferences = 3)
 
-    val lambda = new Lambda(client, config)
-    val actual: APIGatewayProxyResponseEvent = lambda.process(input)
+    val lambda = new Lambda()
+    val actual: APIGatewayProxyResponseEvent = lambda.process(input, client, config)
     val expected: APIGatewayProxyResponseEvent = new APIGatewayProxyResponseEvent()
       .withStatusCode(200)
       .withBody("""["N","P","Q"]""")
@@ -32,8 +32,8 @@ class LambdaTest extends AnyFlatSpec with Matchers with TestContainerUtils {
       .load()
       .withValue("dynamodb.key", ConfigValueFactory.fromAnyRef("invalidKey"))
 
-    val lambda = new Lambda(client, config)
-    val actual: APIGatewayProxyResponseEvent = lambda.process(input)
+    val lambda = new Lambda()
+    val actual: APIGatewayProxyResponseEvent = lambda.process(input, client, config)
     val expected: APIGatewayProxyResponseEvent = new APIGatewayProxyResponseEvent()
       .withStatusCode(500)
       .withBody("The provided key element does not match the schema")


### PR DESCRIPTION
Even when the Lambda was linked via APIGateway it was still complaining about not being able to find an empty constructor. This creates the empty constructor in addition the client now needs a `sdkHttpClient` to be able to run.

Tested & working on sandbox environment.