### PR TITLE
Make 'deploy' job dependent on 'apply' job

### DIFF
--- a/.github/workflows/tdr_deploy.yml
+++ b/.github/workflows/tdr_deploy.yml
@@ -33,6 +33,7 @@ jobs:
       STAGING_ACCOUNT_NUMBER: ${{ secrets.TDR_STAGING_ACCOUNT_NUMBER }}
       PROD_ACCOUNT_NUMBER: ${{ secrets.TDR_PROD_ACCOUNT_NUMBER }}
   deploy:
+    needs: apply
     uses: nationalarchives/tdr-github-actions/.github/workflows/lambda_deploy.yml@main
     with:
       lambda-name: reference-generator


### PR DESCRIPTION
Terraform should be applied successfully before the lambda code is deployed to AWS