### PR TITLE
properly restrict api gateway

### DIFF
--- a/terraform/templates/api_gateway/reference_generator_rest_policy.json.tpl
+++ b/terraform/templates/api_gateway/reference_generator_rest_policy.json.tpl
@@ -10,7 +10,7 @@
         ]
       },
       "Action":"execute-api:Invoke",
-      "Resource":"${api_gateway_arn}"
+      "Resource":"${api_gateway_arn}/*"
     }
   ]
 }


### PR DESCRIPTION
Resource path is also required as part of the arn to properly restrict api invokes