### PR TITLE
Don't update tag during terraform apply

### DIFF
--- a/.github/workflows/tdr_deploy.yml
+++ b/.github/workflows/tdr_deploy.yml
@@ -24,6 +24,7 @@ jobs:
       repo-name: da-reference-generator
       environment: ${{ github.event.inputs.environment }}
       working-directory: 'terraform'
+      update-tag: false
     secrets:
       MANAGEMENT_ACCOUNT: ${{ secrets.TDR_MANAGEMENT_ACCOUNT }}
       WORKFLOW_PAT: ${{ secrets.TDR_WORKFLOW_PAT }}


### PR DESCRIPTION
Tag is updated during the pre-deploy step already, so we don't need to update the tag again in the terraform apply step.

Needs: https://github.com/nationalarchives/tdr-github-actions/pull/61