### PR TITLE
Add mergify.yml & upsert-scala-steward-dependencies-branch.yml scripts

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,20 @@
+queue_rules:
+  - name: default
+    conditions:
+      - "check-success=test / test"
+      - "check-success=security/snyk (nationalarchives)"
+pull_request_rules:
+  - name: automatic merge for Scala Steward
+    conditions:
+      - author=tna-digital-archiving-jenkins
+      - "check-success=test / test"
+      - "check-success=security/snyk (nationalarchives)"
+      - or:
+          - files=build.sbt
+          - files~=^(!?project/)
+    actions:
+      review:
+        type: APPROVE
+        message: Automatically approving Scala Steward
+      queue:
+        name: default

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -15,6 +15,6 @@ pull_request_rules:
     actions:
       review:
         type: APPROVE
-        message: Automatically approving Scala Steward
+        message: Automatically approving Scala Steward updates
       queue:
         name: default

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,12 +1,14 @@
 queue_rules:
   - name: default
     conditions:
-      - "check-success=test / test"
+      - "check-success=Check terraform / terraform-check"
+      - "check-success=Lambda test / test"
 pull_request_rules:
   - name: automatic merge for Scala Steward
     conditions:
       - author=tna-digital-archiving-jenkins
-      - "check-success=test / test"
+      - "check-success=Check terraform / terraform-check"
+      - "check-success=Lambda test / test"
       - or:
           - files=build.sbt
           - files~=^(!?project/)

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -2,13 +2,11 @@ queue_rules:
   - name: default
     conditions:
       - "check-success=test / test"
-      - "check-success=security/snyk (nationalarchives)"
 pull_request_rules:
   - name: automatic merge for Scala Steward
     conditions:
       - author=tna-digital-archiving-jenkins
       - "check-success=test / test"
-      - "check-success=security/snyk (nationalarchives)"
       - or:
           - files=build.sbt
           - files~=^(!?project/)

--- a/.github/workflows/upsert-scala-steward-dependencies-branch.yml
+++ b/.github/workflows/upsert-scala-steward-dependencies-branch.yml
@@ -1,0 +1,23 @@
+name: Upsert `scala-steward-dependencies` branch
+
+on:
+  push:
+    branches: master
+
+jobs:
+  upsert-develop-branch:
+    permissions: write-all
+    runs-on: ubuntu-latest
+    name: Rebase `scala-steward-dependencies` branch to latest `origin/master`
+    steps:
+      - name: Checkout develop branch
+        uses: actions/checkout@v2
+        with:
+          ref: scala-steward-dependencies
+          fetch-depth: 0
+      - name: Rebase `scala-steward-dependencies` branch to latest `origin/main`
+        run: |
+            git config user.email digitalpreservation@nationalarchives.gov.uk
+            git config user.name tna-digital-archiving-jenkins
+            git rebase origin/master
+            git push -f -u origin scala-steward-dependencies

--- a/.github/workflows/upsert-scala-steward-dependencies-branch.yml
+++ b/.github/workflows/upsert-scala-steward-dependencies-branch.yml
@@ -2,13 +2,13 @@ name: Upsert `scala-steward-dependencies` branch
 
 on:
   push:
-    branches: master
+    branches: main
 
 jobs:
   upsert-develop-branch:
     permissions: write-all
     runs-on: ubuntu-latest
-    name: Rebase `scala-steward-dependencies` branch to latest `origin/master`
+    name: Rebase `scala-steward-dependencies` branch to latest `origin/main`
     steps:
       - name: Checkout develop branch
         uses: actions/checkout@v2
@@ -19,5 +19,5 @@ jobs:
         run: |
             git config user.email digitalpreservation@nationalarchives.gov.uk
             git config user.name tna-digital-archiving-jenkins
-            git rebase origin/master
+            git rebase origin/main
             git push -f -u origin scala-steward-dependencies

--- a/.github/workflows/upsert-scala-steward-dependencies-branch.yml
+++ b/.github/workflows/upsert-scala-steward-dependencies-branch.yml
@@ -3,7 +3,6 @@ name: Upsert `scala-steward-dependencies` branch
 on:
   push:
     branches: main
-
 jobs:
   upsert-develop-branch:
     permissions: write-all


### PR DESCRIPTION
`mergify.yml` required for auto merging
`upsert-scala-steward-dependencies-branch.yml` is used to update the `scala-steward-dependencies` anytime there is a merge to main