### PR TITLE
TDRD-625 Restrict ref generator endpoint

### DIFF
--- a/terraform/root_locals.tf
+++ b/terraform/root_locals.tf
@@ -17,7 +17,5 @@ locals {
   reference_counter_table_name         = "${var.project}-reference-counter"
   reference_generator_retries          = 2
   reference_generator_limit            = module.terraform_config_hosting_project.terraform_config["reference_generator_limit"]
-  api_task_role_arn                    = module.terraform_config_hosting_project.terraform_config[local.hosting_environment]["api_task_role_arn"]
-  api_execution_role_arn               = module.terraform_config_hosting_project.terraform_config[local.hosting_environment]["api_execution_role_arn"]
   tdr_vpc_public_ip                    = module.terraform_config_hosting_project.terraform_config["${local.hosting_environment}_ip_public"]
 }

--- a/terraform/root_locals.tf
+++ b/terraform/root_locals.tf
@@ -19,4 +19,5 @@ locals {
   reference_generator_limit            = module.terraform_config_hosting_project.terraform_config["reference_generator_limit"]
   api_task_role_arn                    = module.terraform_config_hosting_project.terraform_config[local.hosting_environment]["api_task_role_arn"]
   api_execution_role_arn               = module.terraform_config_hosting_project.terraform_config[local.hosting_environment]["api_execution_role_arn"]
+  tdr_vpc_public_ip                    = module.terraform_config_hosting_project.terraform_config["${local.hosting_environment}_ip_public"]
 }

--- a/terraform/root_main.tf
+++ b/terraform/root_main.tf
@@ -71,7 +71,7 @@ module "reference_generator_api_gateway" {
   environment = local.hosting_environment
   common_tags = local.hosting_common_tags
   api_rest_policy = templatefile("${path.module}/templates/api_gateway/reference_generator_rest_policy.json.tpl", {
-    api_gateway_arn = module.reference_generator_api_gateway.api_execution_arn
+    api_gateway_arn   = module.reference_generator_api_gateway.api_execution_arn
     tdr_vpc_public_ip = jsonencode(local.tdr_vpc_public_ip)
   })
   api_method_settings = [{

--- a/terraform/root_main.tf
+++ b/terraform/root_main.tf
@@ -71,9 +71,10 @@ module "reference_generator_api_gateway" {
   environment = local.hosting_environment
   common_tags = local.hosting_common_tags
   api_rest_policy = templatefile("${path.module}/templates/api_gateway/reference_generator_rest_policy.json.tpl", {
-    api_gateway_arn        = module.reference_generator_api_gateway.api_execution_arn
-    api_task_role_arn      = local.api_task_role_arn
-    api_execution_role_arn = local.api_execution_role_arn
+    api_gateway_arn = module.reference_generator_api_gateway.api_execution_arn
+    # api_task_role_arn      = local.api_task_role_arn
+    # api_execution_role_arn = local.api_execution_role_arn
+    tdr_vpc_public_ip = jsonencode(local.tdr_vpc_public_ip)
   })
   api_method_settings = [{
     method_path        = "*/*"

--- a/terraform/root_main.tf
+++ b/terraform/root_main.tf
@@ -72,8 +72,6 @@ module "reference_generator_api_gateway" {
   common_tags = local.hosting_common_tags
   api_rest_policy = templatefile("${path.module}/templates/api_gateway/reference_generator_rest_policy.json.tpl", {
     api_gateway_arn = module.reference_generator_api_gateway.api_execution_arn
-    # api_task_role_arn      = local.api_task_role_arn
-    # api_execution_role_arn = local.api_execution_role_arn
     tdr_vpc_public_ip = jsonencode(local.tdr_vpc_public_ip)
   })
   api_method_settings = [{

--- a/terraform/templates/api_gateway/reference_generator_rest_policy.json.tpl
+++ b/terraform/templates/api_gateway/reference_generator_rest_policy.json.tpl
@@ -1,16 +1,22 @@
 {
-  "Version":"2012-10-17",
-  "Statement":[
+  "Version": "2012-10-17",
+  "Statement": [
     {
-      "Effect":"Allow",
-      "Principal":{
-        "AWS":[
-          "${api_task_role_arn}",
-          "${api_execution_role_arn}"
-        ]
-      },
-      "Action":"execute-api:Invoke",
-      "Resource":"${api_gateway_arn}/*"
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "execute-api:Invoke",
+      "Resource": "${api_gateway_arn}/*"
+    },
+    {
+      "Effect": "Deny",
+      "Principal": "*",
+      "Action": "execute-api:Invoke",
+      "Resource": "${api_gateway_arn}/*",
+      "Condition": {
+        "NotIpAddress": {
+          "aws:SourceIp": ${tdr_vpc_public_ip}
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
Restricts invocation of ref generator endpoint to only TDR's NAT gateway public ip address