### PR TITLE
Using a vulnerable version of the commons logging

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,8 @@ lazy val root = (project in file("."))
     )
   )
 
+dependencyOverrides += "commons-logging" % "commons-logging" % "1.3.5"
+
 (assembly / assemblyJarName) := "reference-generator.jar"
 
 (assembly / assemblyMergeStrategy) := {


### PR DESCRIPTION
Override to latest version of library

Appears AWS DynamoDb SDK pulling in the vulnerable version