### PR TITLE
Update tdr_deploy.yml to tf 1.12.2

### DIFF
--- a/.github/workflows/tdr_deploy.yml
+++ b/.github/workflows/tdr_deploy.yml
@@ -26,6 +26,7 @@ jobs:
       environment: ${{ github.event.inputs.environment }}
       working-directory: 'terraform'
       update-tag: false
+      terraform-version: 1.12.2
     secrets:
       MANAGEMENT_ACCOUNT: ${{ secrets.TDR_MANAGEMENT_ACCOUNT }}
       WORKFLOW_PAT: ${{ secrets.TDR_WORKFLOW_PAT }}

--- a/.github/workflows/tdr_test.yml
+++ b/.github/workflows/tdr_test.yml
@@ -13,7 +13,7 @@ jobs:
     name: Check terraform
     uses: nationalarchives/tdr-github-actions/.github/workflows/terraform_check.yml@main
     with:
-      terraform-version: '1.9.8'
+      terraform-version: 1.12.2
       working-directory: terraform
     secrets:
       MANAGEMENT_ACCOUNT: ${{ secrets.TDR_MANAGEMENT_ACCOUNT }}

--- a/terraform/tdr_root_backend.tf
+++ b/terraform/tdr_root_backend.tf
@@ -4,6 +4,6 @@ terraform {
     key            = "reference-generator.state"
     region         = "eu-west-2"
     encrypt        = true
-    dynamodb_table = "tdr-terraform-state-lock"
+    use_lockfile   = true
   }
 }

--- a/terraform/tdr_root_backend.tf
+++ b/terraform/tdr_root_backend.tf
@@ -1,9 +1,9 @@
 terraform {
   backend "s3" {
-    bucket         = "tdr-terraform-state"
-    key            = "reference-generator.state"
-    region         = "eu-west-2"
-    encrypt        = true
-    use_lockfile   = true
+    bucket       = "tdr-terraform-state"
+    key          = "reference-generator.state"
+    region       = "eu-west-2"
+    encrypt      = true
+    use_lockfile = true
   }
 }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.76.0"
+      version = "~> 6.0"
     }
   }
   required_version = ">= 1.12.2"

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "~> 5.0"
     }
   }
   required_version = ">= 1.12.2"

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -5,5 +5,5 @@ terraform {
       version = ">= 5.76.0"
     }
   }
-  required_version = ">= 1.9.8"
+  required_version = ">= 1.12.2"
 }


### PR DESCRIPTION
Upgrade to provider 6 needs a terraform init -upgrade command which I will do from a local machine at some point.  Have pinned provider to any V5.x.x
Upgraded to tf 1.12.2 and is now using S3 lockfile and working as expected